### PR TITLE
Decoupled from elixir and now we can call compiler in erlang shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ def add(a)
 - [x] Stop using PosParser to guess if a call is a local call. It can be a lot easier to just consider
 all call local calls, but call of modules like Map.get(...)
 - [ ] Use real tuples in conversor instead of strings
+- [ ] Define atoms using strings: `:"oii"`. Must work with single and double quotes.
 - [ ] Support to range syntax
 - [ ] Support to try catch. Finally too?
 - [ ] Support to multiline if with elif and else

--- a/src/Fcore/__init__.fy
+++ b/src/Fcore/__init__.fy
@@ -1,13 +1,13 @@
 def eval_file(module_name, file_path):
-    text = File.read(file_path) |> elem(1)
+    text = Elixir.File.read(file_path) |> Elixir.Kernel.elem(1)
 
     eval_string(module_name, text)
 
 def eval_string(module_name, text):
     state_n_converted = Fcore.Generator.Compiler.lexer_parse_convert_file(module_name, text)
 
-    state = Enum.at(state_n_converted, 0)
-    converted = Enum.at(state_n_converted, 1)
+    state = Elixir.Enum.at(state_n_converted, 0)
+    converted = Elixir.Enum.at(state_n_converted, 1)
 
     case converted:
         None ->
@@ -15,7 +15,7 @@ def eval_string(module_name, text):
             None
         _ ->
             converted
-                |> Code.eval_string()
-                |> elem(0)
-                |> Code.eval_quoted()
-                |> elem(0)
+                |> Elixir.Code.eval_string()
+                |> Elixir.Kernel.elem(0)
+                |> Elixir.Code.eval_quoted()
+                |> Elixir.Kernel.elem(0)

--- a/src/Fcore/errors/utils.fy
+++ b/src/Fcore/errors/utils.fy
@@ -3,96 +3,96 @@ def print_error(module_name, state, text):
 
     guide = string_with_arrows(state, text)
 
-    Enum.join([
+    Elixir.Enum.join([
         'File: ', module_name,
         ', line: ',
-        (Map.get(state, "error") |> Map.get('pos_start') |> Map.get('ln')) + 1,
+        (Elixir.Map.get(state, "error") |> Elixir.Map.get('pos_start') |> Elixir.Map.get('ln')) + 1,
         '\n\n', guide, '\n\n',
-        Map.get(state, "error") |> Map.get('msg')
+        Elixir.Map.get(state, "error") |> Elixir.Map.get('msg')
     ])
-        |> IO.puts()
+        |> Elixir.IO.puts()
 
 def string_with_arrows(state, text):
-    error = Map.get(state, "error")
-    pos_start = Map.get(error, 'pos_start')
-    pos_end = Map.get(error, 'pos_end')
+    error = Elixir.Map.get(state, "error")
+    pos_start = Elixir.Map.get(error, 'pos_start')
+    pos_end = Elixir.Map.get(error, 'pos_end')
 
     # number of lines that we will show above the first line with error
     # and number of lines that we will show bellow the last line with error
     num_show_above = 2
     num_show_bellow = 0
 
-    lines = String.split(text, '\n')
+    lines = Elixir.String.split(text, '\n')
 
-    lines_with_error = Range.new(pos_start |> Map.get('ln'), pos_end |> Map.get('ln'))
+    lines_with_error = Range.new(pos_start |> Elixir.Map.get('ln'), pos_end |> Elixir.Map.get('ln'))
 
-    col_range_per_line = Range.new(0, Enum.count(lines))
-        |> Enum.map(lambda ln:
+    col_range_per_line = Range.new(0, Elixir.Enum.count(lines))
+        |> Elixir.Enum.map(lambda ln:
             case:
                 ln in lines_with_error ->
                     case:
                         ln == 0 ->
-                            [Map.get(pos_start, 'col'), String.length(Enum.at(lines, 0))]
-                        ln == Enum.at(lines_with_error, -1) ->
+                            [Elixir.Map.get(pos_start, 'col'), Elixir.String.length(Elixir.Enum.at(lines, 0))]
+                        ln == Elixir.Enum.at(lines_with_error, -1) ->
                             [
-                                0 if Enum.count(lines_with_error) > 1 else Map.get(pos_start, 'col'),
-                                Map.get(pos_end, 'col')
+                                0 if Elixir.Enum.count(lines_with_error) > 1 else Elixir.Map.get(pos_start, 'col'),
+                                Elixir.Map.get(pos_end, 'col')
                             ]
-                        True -> [0, String.length(Enum.at(lines, 0))]
+                        True -> [0, Elixir.String.length(Elixir.Enum.at(lines, 0))]
                 True -> [None, None]
         )
 
     lines_to_display = lines
-        |> Enum.zip(Range.new(0, Enum.count(lines)))
-        |> Enum.slice(Range.new(
-            max(0, Enum.at(lines_with_error, 0) - num_show_above),
-            Enum.at(lines_with_error, -1) + num_show_bellow
+        |> Elixir.Enum.zip(Range.new(0, Elixir.Enum.count(lines)))
+        |> Elixir.Enum.slice(Range.new(
+            max(0, Elixir.Enum.at(lines_with_error, 0) - num_show_above),
+            Elixir.Enum.at(lines_with_error, -1) + num_show_bellow
         ))
 
     lines_to_display
-        |> Enum.map(lambda item_n_index:
-            item = elem(item_n_index, 0)
-            index = elem(item_n_index, 1)
+        |> Elixir.Enum.map(lambda item_n_index:
+            item = Elixir.Kernel.elem(item_n_index, 0)
+            index = Elixir.Kernel.elem(item_n_index, 1)
 
             arrows = case index in lines_with_error:
                 True ->
-                    col_start = col_range_per_line |> Enum.at(index) |> Enum.at(0)
-                    col_end = col_range_per_line |> Enum.at(index) |> Enum.at(1)
+                    col_start = col_range_per_line |> Elixir.Enum.at(index) |> Elixir.Enum.at(0)
+                    col_end = col_range_per_line |> Elixir.Enum.at(index) |> Elixir.Enum.at(1)
 
-                    arrows = String.duplicate('^', String.length(text))
-                    empty = String.duplicate(' ', String.length(text))
+                    arrows = Elixir.String.duplicate('^', Elixir.String.length(text))
+                    empty = Elixir.String.duplicate(' ', Elixir.String.length(text))
 
-                    start = String.slice(empty, Range.new(0, col_start))
-                    middle = String.slice(arrows, Range.new(col_start, col_end))
-                    _end = String.slice(empty, Range.new(col_end, String.length(text)))
+                    start = Elixir.String.slice(empty, Range.new(0, col_start))
+                    middle = Elixir.String.slice(arrows, Range.new(col_start, col_end))
+                    _end = Elixir.String.slice(empty, Range.new(col_end, Elixir.String.length(text)))
 
-                    Enum.join([start, middle, _end])
+                    Elixir.Enum.join([start, middle, _end])
                 False -> ''
 
             [item, index, arrows]
         )
-        |> Enum.map(lambda item_index_arrows:
-            item = Enum.at(item_index_arrows, 0)
-            index = Enum.at(item_index_arrows, 1)
-            arrows = Enum.at(item_index_arrows, 2)
+        |> Elixir.Enum.map(lambda item_index_arrows:
+            item = Elixir.Enum.at(item_index_arrows, 0)
+            index = Elixir.Enum.at(item_index_arrows, 1)
+            arrows = Elixir.Enum.at(item_index_arrows, 2)
 
-            prefix = Enum.count(Integer.digits(Map.get(pos_end, 'ln')))
+            prefix = Elixir.Enum.count(Integer.digits(Elixir.Map.get(pos_end, 'ln')))
 
-            # num_line = Enum.join([index + 1, " "])
-            num_line = IO.ANSI.format([
-                :bright, :black, to_string(index + 1),
-                String.duplicate(' ', (prefix - Enum.count(Integer.digits(index))) + 1)
+            # num_line = Elixir.Enum.join([index + 1, " "])
+            num_line = Elixir.IO.ANSI.format([
+                :bright, :black, Elixir.Kernel.to_string(index + 1),
+                Elixir.String.duplicate(' ', (prefix - Elixir.Enum.count(Integer.digits(index))) + 1)
             ])
 
-            item = Enum.join([num_line, item])
+            item = Elixir.Enum.join([num_line, item])
 
-            arrows = Enum.join([
-                String.duplicate(' ', prefix),
+            arrows = Elixir.Enum.join([
+                Elixir.String.duplicate(' ', prefix),
                 arrows
             ])
 
             [item, arrows]
         )
-        |> List.flatten()
-        |> Enum.filter(lambda i: String.trim(i) != '' if is_bitstring(i) else True)
-        |> Enum.join('\n')
+        |> Elixir.List.flatten()
+        |> Elixir.Enum.filter(lambda i: Elixir.String.trim(i) != '' if Elixir.Kernel.is_bitstring(i) else True)
+        |> Elixir.Enum.join('\n')

--- a/src/Fcore/generator/Compiler.fy
+++ b/src/Fcore/generator/Compiler.fy
@@ -3,13 +3,31 @@ def compile_project(project_path):
 
 
 def compile_project(project_path, destine):
-    compiled_folder = [project_path, destine] |> Enum.join('/')
+    compiled_folder = [project_path, destine] |> Elixir.Enum.join('/')
 
     # Ensure compiled folder is created
-    File.mkdir_p!(compiled_folder)
+    Elixir.File.mkdir_p!(compiled_folder)
+
+    # Copy elixir beams to folder
+    copy_elixir_beams(compiled_folder)
 
     compile_project_to_binary(project_path, compiled_folder)
 
+
+def copy_elixir_beams(compiled_folder):
+    elixir_path = '/usr/lib/elixir/lib/elixir/ebin'
+
+    case Elixir.File.exists?(elixir_path):
+        True -> Elixir.Enum.join([elixir_path, '*'], '/')
+            |> Elixir.Path.wildcard()
+            |> Elixir.Enum.each(lambda beam_file:
+                file_name = beam_file
+                    |> Elixir.String.split('/')
+                    |> Elixir.List.last()
+
+                Elixir.File.cp!(beam_file, Elixir.Enum.join([compiled_folder, file_name], '/'))
+            )
+        False -> :error
 
 def compile_project_to_binary(directory_path, compiled_folder):
     # Return a list of each module compiled into elixir AST in binary
@@ -21,42 +39,42 @@ def compile_project_to_binary(directory_path, compiled_folder):
     # Now, you should be able to call any module of this project in iex
 
     [directory_path, "**/*.fy"]
-        |> Enum.join('/')
-        |> Path.wildcard()
-        |> Enum.sort()
-        |> parallel_map(lambda full_path:
+        |> Elixir.Enum.join('/')
+        |> Elixir.Path.wildcard()
+        |> Elixir.Enum.sort()
+        |> Elixir.Enum.map(lambda full_path:
             module_name = get_module_name(directory_path, full_path)
 
-            IO.puts(Enum.join(["Compiling module: ", module_name]))
+            Elixir.IO.puts(Elixir.Enum.join(["Compiling module: ", module_name]))
 
             state_n_converted = lexer_parse_convert_file(
-                module_name, File.read(full_path) |> elem(1)
+                module_name, Elixir.File.read(full_path) |> Elixir.Kernel.elem(1)
             )
 
-            state = Enum.at(state_n_converted, 0)
-            converted = Enum.at(state_n_converted, 1)
+            state = Elixir.Enum.at(state_n_converted, 0)
+            converted = Elixir.Enum.at(state_n_converted, 1)
 
-            case Map.get(state, "error"):
+            case Elixir.Map.get(state, "error"):
                 None ->
-                    (quoted, _) = Code.eval_string(converted)
+                    (quoted, _) = Elixir.Code.eval_string(converted)
 
                     # Its super important to use this Module.create function
                     # to ensure that our module binary will not have
                     # Elixer. in the begin of the module name
                     (_, _, binary, _) = Module.create(
-                        String.to_atom(module_name), quoted, Macro.Env.location(__ENV__)
+                        Elixir.String.to_atom(module_name), quoted, Macro.Env.location(__ENV__)
                     )
 
-                    File.write(
-                        Enum.join([compiled_folder, "/", module_name, ".beam"]),
+                    Elixir.File.write(
+                        Elixir.Enum.join([compiled_folder, "/", module_name, ".beam"]),
                         binary,
                         mode=:binary
                     )
                 _ ->
-                    IO.puts("Compilation error:")
-                    IO.puts("file path:")
-                    IO.puts(full_path)
-                    text = File.read(full_path) |> elem(1)
+                    Elixir.IO.puts("Compilation error:")
+                    Elixir.IO.puts("file path:")
+                    Elixir.IO.puts(full_path)
+                    text = Elixir.File.read(full_path) |> Elixir.Kernel.elem(1)
                     Fcore.Errors.Utils.print_error(module_name, state, text)
                     raise "end"
         )
@@ -65,18 +83,18 @@ def compile_project_to_binary(directory_path, compiled_folder):
 def lexer_parse_convert_file(module_name, text):
     lexed = Fcore.Lexer.execute(text)
 
-    state = case Map.get(lexed, "error"):
+    state = case Elixir.Map.get(lexed, "error"):
         None ->
-            tokens = Map.get(lexed, "tokens")
+            tokens = Elixir.Map.get(lexed, "tokens")
             Fcore.Parser.execute(tokens)
         _ ->
             lexed
 
 
-    ast = Map.get(state, 'node')
+    ast = Elixir.Map.get(state, 'node')
 
     # 2º Convert each node from json to Fython format
-    case Map.get(state, 'error'):
+    case Elixir.Map.get(state, 'error'):
         None -> [state, Fcore.Generator.Conversor.convert(ast)]
         _ -> [state, None]
 
@@ -89,28 +107,28 @@ def get_module_name(project_full_path, module_full_path):
     # we wil remove this name and the module name passes to be
     # the name of this file parent folder
 
-    directory_path = project_full_path |> String.replace(".", "\.")
+    directory_path = project_full_path |> Elixir.String.replace(".", "\.")
 
-    regex = Regex.compile(Enum.join(["^", project_full_path, "/"]))
-        |> elem(1)
+    regex = Elixir.Regex.compile(Elixir.Enum.join(["^", project_full_path, "/"]))
+        |> Elixir.Kernel.elem(1)
 
-    name = Regex.replace(regex, module_full_path, "")
-        |> String.replace("/", ".")
+    name = Elixir.Regex.replace(regex, module_full_path, "")
+        |> Elixir.String.replace("/", ".")
 
-    final = Regex.compile("\.fy$") |> elem(1)
-        |> Regex.replace(name, "")
-        |> String.split('.')
-        |> Enum.map(lambda i: String.capitalize(i))
+    final = Elixir.Regex.compile("\.fy$") |> Elixir.Kernel.elem(1)
+        |> Elixir.Regex.replace(name, "")
+        |> Elixir.String.split('.')
+        |> Elixir.Enum.map(lambda i: Elixir.String.capitalize(i))
 
-    case final |> List.last():
+    case final |> Elixir.List.last():
         "__init__" ->
             final
-                |> List.pop_at(-1)
-                |> elem(1)
-                |> Enum.join('.')
-        _ -> final |> Enum.join('.')
+                |> Elixir.List.pop_at(-1)
+                |> Elixir.Kernel.elem(1)
+                |> Elixir.Enum.join('.')
+        _ -> final |> Elixir.Enum.join('.')
 
 def parallel_map(collection, func):
     collection
-        |> Enum.map(lambda i: Task.async(lambda: func(i)))
-        |> Enum.map(lambda i: Task.await(i, :infinity))
+        |> Elixir.Enum.map(lambda i: Task.async(lambda: func(i)))
+        |> Elixir.Enum.map(lambda i: Task.await(i, :infinity))

--- a/src/Fcore/generator/Compiler.fy
+++ b/src/Fcore/generator/Compiler.fy
@@ -60,9 +60,9 @@ def compile_project_to_binary(directory_path, compiled_folder):
 
                     # Its super important to use this Module.create function
                     # to ensure that our module binary will not have
-                    # Elixer. in the begin of the module name
-                    (_, _, binary, _) = Module.create(
-                        Elixir.String.to_atom(module_name), quoted, Macro.Env.location(__ENV__)
+                    # Elixir. in the begin of the module name
+                    (_, _, binary, _) = Elixir.Module.create(
+                        Elixir.String.to_atom(module_name), quoted, Elixir.Macro.Env.location(__ENV__)
                     )
 
                     Elixir.File.write(
@@ -106,8 +106,6 @@ def get_module_name(project_full_path, module_full_path):
     # if file name is __init__.fy
     # we wil remove this name and the module name passes to be
     # the name of this file parent folder
-
-    directory_path = project_full_path |> Elixir.String.replace(".", "\.")
 
     regex = Elixir.Regex.compile(Elixir.Enum.join(["^", project_full_path, "/"]))
         |> Elixir.Kernel.elem(1)

--- a/src/Fcore/generator/Conversor.fy
+++ b/src/Fcore/generator/Conversor.fy
@@ -1,5 +1,5 @@
 def convert(node):
-    func = case Map.get(node, "NodeType"):
+    func = case Elixir.Map.get(node, "NodeType"):
         "StatementsNode"    -> convert_statements_node(node)
         "NumberNode"        -> convert_number_node(node)
         "AtomNode"          -> convert_atom_node(node)
@@ -24,39 +24,39 @@ def convert(node):
         "FuncAsVariableNode" -> convert_funcasvariable_node(node)
 
 def convert_number_node(node):
-    node |> Map.get("tok") |> Map.get("value") |> to_string()
+    node |> Elixir.Map.get("tok") |> Elixir.Map.get("value") |> Elixir.Kernel.to_string()
 
 def convert_atom_node(node):
-    Enum.join([":", node |> Map.get("tok") |> Map.get("value")])
+    Elixir.Enum.join([":", node |> Elixir.Map.get("tok") |> Elixir.Map.get("value")])
 
 def convert_string_node(node):
     value = node
-        |> Map.get("tok")
-        |> Map.get("value")
+        |> Elixir.Map.get("tok")
+        |> Elixir.Map.get("value")
 
     # We need to remove this dependency, eventually
     # Convert to json is te easiest way that we found for scape
     # `"` and `/` (and probably another chars too)
-    Enum.join(['"', value ,'"'])
+    Elixir.Enum.join(['"', value ,'"'])
 
 def convert_varaccess_node(node):
-    tok_value = node |> Map.get("var_name_tok") |> Map.get("value")
+    tok_value = node |> Elixir.Map.get("var_name_tok") |> Elixir.Map.get("value")
 
-    pinned = Map.get(node, "pinned")
+    pinned = Elixir.Map.get(node, "pinned")
 
-    pin_node = lambda i: Enum.join(["{:^, [], [", i, "]}"]) if pinned else i
+    pin_node = lambda i: Elixir.Enum.join(["{:^, [], [", i, "]}"]) if pinned else i
 
     case:
         tok_value == "True" -> "true"
         tok_value == "False" -> "false"
         tok_value == "None" -> "nil"
-        True -> Enum.join(["{:", tok_value, ", [], Elixir}"]) |> pin_node()
+        True -> Elixir.Enum.join(["{:", tok_value, ", [], Elixir}"]) |> pin_node()
 
 def convert_patternmatch_node(node):
-    left = Map.get(node, 'left_node') |> convert()
-    right = Map.get(node, 'right_node') |> convert()
+    left = Elixir.Map.get(node, 'left_node') |> convert()
+    right = Elixir.Map.get(node, 'right_node') |> convert()
 
-    Enum.join([
+    Elixir.Enum.join([
         "{:=, ",
         "[], ",
         "[", left , ", ", right , "]",
@@ -64,11 +64,11 @@ def convert_patternmatch_node(node):
     ])
 
 def convert_if_node(node):
-    comp_expr = convert(node |> Map.get("comp_expr"))
-    true_case = convert(node |> Map.get("true_case"))
-    false_case = convert(node |> Map.get("false_case"))
+    comp_expr = convert(node |> Elixir.Map.get("comp_expr"))
+    true_case = convert(node |> Elixir.Map.get("true_case"))
+    false_case = convert(node |> Elixir.Map.get("false_case"))
 
-    Enum.join([
+    Elixir.Enum.join([
         "{:if, [context: Elixir, import: Kernel], [",
         comp_expr,
         ", [do: ",
@@ -80,118 +80,118 @@ def convert_if_node(node):
 
 def convert_lambda_node(node):
     params = node
-        |> Map.get("arg_name_toks")
-        |> Enum.map(lambda param:
-            Enum.join([
+        |> Elixir.Map.get("arg_name_toks")
+        |> Elixir.Enum.map(lambda param:
+            Elixir.Enum.join([
                 "{:",
-                param |> Map.get('value'),
+                param |> Elixir.Map.get('value'),
                 ", [context: Elixir, import: IEx.Helpers], Elixir}"
             ])
         )
-        |> Enum.join(", ")
+        |> Elixir.Enum.join(", ")
 
-    params = ['[', params, ']'] |> Enum.join('')
+    params = ['[', params, ']'] |> Elixir.Enum.join('')
 
-    Enum.join([
+    Elixir.Enum.join([
         "{:fn, [], [{:->, [], [",
         params,
         ", ",
-        convert(node |> Map.get('body_node')),
+        convert(node |> Elixir.Map.get('body_node')),
         "]}]}"
     ])
 
 def convert_list_node(node):
-    Enum.join([
+    Elixir.Enum.join([
         "[",
-        Enum.join(Enum.map(node |> Map.get("element_nodes"), &convert/1), ", "),
+        Elixir.Enum.join(Elixir.Enum.map(node |> Elixir.Map.get("element_nodes"), &convert/1), ", "),
         "]"
     ])
 
 def convert_map_node(node):
     pairs = node
-        |> Map.get("pairs_list")
-        |> Enum.map(lambda pair:
+        |> Elixir.Map.get("pairs_list")
+        |> Elixir.Enum.map(lambda pair:
             [key, value] = pair
-            Enum.join(["{", convert(key), ", ", convert(value), "}"])
+            Elixir.Enum.join(["{", convert(key), ", ", convert(value), "}"])
         )
-        |> Enum.join(', ')
+        |> Elixir.Enum.join(', ')
 
-    r = Enum.join(["{:%{}, [], [", pairs, "]}"])
+    r = Elixir.Enum.join(["{:%{}, [], [", pairs, "]}"])
 
 def convert_statements_node(node):
     content = node
-        |> Map.get("statement_nodes")
-        |> Enum.map(lambda i: convert(i))
+        |> Elixir.Map.get("statement_nodes")
+        |> Elixir.Enum.map(lambda i: convert(i))
 
-    case Enum.count(content):
-        1 -> Enum.at(content, 0)
-        _ -> Enum.join([
-            '{:__block__, [line: 0], [', Enum.join(content, ', '), ']}'
+    case Elixir.Enum.count(content):
+        1 -> Elixir.Enum.at(content, 0)
+        _ -> Elixir.Enum.join([
+            '{:__block__, [line: 0], [', Elixir.Enum.join(content, ', '), ']}'
         ])
 
 def convert_deffunc_node(node):
-    name = node |> Map.get("var_name_tok") |> Map.get("value")
-    statements_node = node |> Map.get("body_node")
+    name = node |> Elixir.Map.get("var_name_tok") |> Elixir.Map.get("value")
+    statements_node = node |> Elixir.Map.get("body_node")
 
     arguments = node
-        |> Map.get("arg_name_toks")
-        |> Enum.map(lambda argument:
-            Enum.join(["{:", Map.get(argument, "value"), ", [], Elixir}"])
+        |> Elixir.Map.get("arg_name_toks")
+        |> Elixir.Enum.map(lambda argument:
+            Elixir.Enum.join(["{:", Elixir.Map.get(argument, "value"), ", [], Elixir}"])
         )
-        |> Enum.join(', ')
+        |> Elixir.Enum.join(', ')
 
-    Enum.join([
+    Elixir.Enum.join([
         "{:def, [line: 0], [{:", name, ", [line: 0], [",
         arguments, "]}, [do: ", convert(statements_node), "]]}"
     ])
 
 def convert_case_node(node):
-    expr = convert(node |> Map.get("expr")) if node |> Map.get("expr") else None
+    expr = convert(node |> Elixir.Map.get("expr")) if node |> Elixir.Map.get("expr") else None
 
     arguments = node
-        |> Map.get("cases")
-        |> Enum.map(lambda left_right:
-            left = Enum.at(left_right, 0)
-            right = Enum.at(left_right, 1)
+        |> Elixir.Map.get("cases")
+        |> Elixir.Enum.map(lambda left_right:
+            left = Elixir.Enum.at(left_right, 0)
+            right = Elixir.Enum.at(left_right, 1)
 
-            Enum.join([
+            Elixir.Enum.join([
                 "{:->, [], [[", convert(left), "], ", convert(right), "]}"
             ], '')
         )
-        |> Enum.join(', ')
+        |> Elixir.Enum.join(', ')
 
     case expr:
-        None -> Enum.join([
+        None -> Elixir.Enum.join([
                 "{:cond, [], [[do: [", arguments, "]]]}"
             ])
-        _ -> Enum.join([
+        _ -> Elixir.Enum.join([
                 "{:case, [], [", expr, ", [do: [", arguments, "]]]}"
             ])
 
 def convert_in_node(node):
-    left = Map.get(node, "left_expr") |> convert()
-    right = Map.get(node, "right_expr") |> convert()
+    left = Elixir.Map.get(node, "left_expr") |> convert()
+    right = Elixir.Map.get(node, "right_expr") |> convert()
 
-    Enum.join([
+    Elixir.Enum.join([
         "{:in, [context: Elixir, import: Kernel], [", left, ", ", right, "]}"
     ])
 
 def convert_raise_node(node):
-    expr = Map.get(node, "expr") |> convert()
+    expr = Elixir.Map.get(node, "expr") |> convert()
 
-    Enum.join(["{:raise, [context: Elixir, import: Kernel], [", expr, "]}"])
+    Elixir.Enum.join(["{:raise, [context: Elixir, import: Kernel], [", expr, "]}"])
 
 def convert_funcasvariable_node(node):
-    name = node |> Map.get("var_name_tok") |> Map.get("value")
-    arity = node |> Map.get("arity")
-    Enum.join([
+    name = node |> Elixir.Map.get("var_name_tok") |> Elixir.Map.get("value")
+    arity = node |> Elixir.Map.get("arity")
+    Elixir.Enum.join([
         "{:&, [], [{:/, [context: Elixir, import: Kernel], [{:",
         name, ", [], Elixir}, ", arity, "]}]}"
     ])
 
 def convert_binop_node(node):
-    a = convert(Map.get(node, "left_node"))
-    b = convert(Map.get(node, "right_node"))
+    a = convert(Elixir.Map.get(node, "left_node"))
+    b = convert(Elixir.Map.get(node, "right_node"))
 
     simple_ops = {
         "PLUS": '+', "MINUS": '-', "MUL": '*', "DIV": '/',
@@ -199,34 +199,34 @@ def convert_binop_node(node):
         "EE": '==', 'NE': '!='
     }
 
-    tok_type = node |> Map.get("op_tok") |> Map.get("type")
-    tok_value = node |> Map.get("op_tok") |> Map.get("value")
+    tok_type = node |> Elixir.Map.get("op_tok") |> Elixir.Map.get("type")
+    tok_value = node |> Elixir.Map.get("op_tok") |> Elixir.Map.get("value")
 
     cases = [
-        Map.has_key?(simple_ops, tok_type),
+        Elixir.Map.has_key?(simple_ops, tok_type),
         tok_type == "POW",
         tok_type == "KEYWORD" and tok_value == "or",
         tok_type == "KEYWORD" and tok_value == "and"
     ]
 
     simple_op_node = lambda simple_ops, node, a, b:
-        op = simple_ops |> Map.get(node |> Map.get("op_tok") |> Map.get("type"))
-        Enum.join([
+        op = simple_ops |> Elixir.Map.get(node |> Elixir.Map.get("op_tok") |> Elixir.Map.get("type"))
+        Elixir.Enum.join([
             "{:", op, ", [context: Elixir, import: Kernel], [", a, ", ", b, "]}"
         ])
 
     power_op = lambda a, b:
-        Enum.join([
+        Elixir.Enum.join([
             "{{:., [], [:math, :pow]}, [], [", a, ", ", b, "]}"
         ])
 
     or_op = lambda a, b:
-        Enum.join([
+        Elixir.Enum.join([
             "{:or, [context: Elixir, import: Kernel], [", a, ", ", b, "]}"
         ])
 
     and_op = lambda a, b:
-        Enum.join([
+        Elixir.Enum.join([
             "{:and, [context: Elixir, import: Kernel], [", a, ", ", b, "]}"
         ])
 
@@ -239,81 +239,79 @@ def convert_binop_node(node):
 
 def convert_call_node(node):
     args = node
-        |> Map.get("arg_nodes")
-        |> Enum.map(&convert/1)
+        |> Elixir.Map.get("arg_nodes")
+        |> Elixir.Enum.map(&convert/1)
 
     keywords = node
-        |> Map.get("keywords")
-        |> Map.to_list()
-        |> Enum.map(lambda k_v:
-            k = elem(k_v, 0)
-            v = elem(k_v, 1)
-            Enum.join(["[", k, ": ", convert(v), "]"])
+        |> Elixir.Map.get("keywords")
+        |> Elixir.Map.to_list()
+        |> Elixir.Enum.map(lambda k_v:
+            k = Elixir.Kernel.elem(k_v, 0)
+            v = Elixir.Kernel.elem(k_v, 1)
+            Elixir.Enum.join(["[", k, ": ", convert(v), "]"])
         )
 
-    arguments = Enum.join([
+    arguments = Elixir.Enum.join([
         "[",
-        [args, keywords] |> List.flatten() |> Enum.join(", "),
+        [args, keywords] |> Elixir.List.flatten() |> Elixir.Enum.join(", "),
         "]"
     ], "")
 
-    case Map.get(node, "local_call"):
+    case Elixir.Map.get(node, "local_call"):
         True ->
-            func_to_call = convert(Map.get(node, "node_to_call"))
-            Enum.join(["{{:., [], [", func_to_call, "]}, [], ", arguments, "}"])
+            func_to_call = convert(Elixir.Map.get(node, "node_to_call"))
+            Elixir.Enum.join(["{{:., [], [", func_to_call, "]}, [], ", arguments, "}"])
         False ->
-            # node_to_call will always be a VarAccessNode on a module call. E.g: Map.get
+            # node_to_call will always be a VarAccessNode on a module call. E.g: Elixir.Map.get
             func_name = node
-                |> Map.get("node_to_call")
-                |> Map.get("var_name_tok")
-                |> Map.get("value")
+                |> Elixir.Map.get("node_to_call")
+                |> Elixir.Map.get("var_name_tok")
+                |> Elixir.Map.get("value")
 
-            case String.contains?(func_name, '.'):
+            case Elixir.String.contains?(func_name, '.'):
                 True ->
-                    modules = func_name |> String.split(".") |> List.pop_at(-1) |> elem(1)
-                    function = func_name |> String.split(".") |> Enum.at(-1)
+                    modules = func_name |> Elixir.String.split(".") |> Elixir.List.pop_at(-1) |> Elixir.Kernel.elem(1)
+                    function = func_name |> Elixir.String.split(".") |> Elixir.Enum.at(-1)
 
-                    modules = modules
-                        |> Enum.map(lambda i: Enum.join([':', i], ''))
-                        |> Enum.join(', ')
+                    # for fython modules we need to use the elixir
+                    # syntax for erlang calls. Doing this way, we prevent
+                    # Elixer compiler from adding 'Elixir.' to module name to call
 
-                    r = Enum.join([
-                        '{{:., [], [{:__aliases__, [alias: false], [',
-                        modules,
-                        ']}, :', function,']}, [], ', arguments, '}'
-                    ])
+                    module = Elixir.Enum.join(modules, ".")
+
+                    Elixir.Enum.join(["{{:., [], [", module, ", :", function, "]}, [], ", arguments, "}"])
                 False ->
                     # this is for call a function that is defined in
                     # the same module
-                    Enum.join(["{:", func_name, ", [], ", arguments, "}"])
+                    Elixir.Enum.join(["{:", func_name, ", [], ", arguments, "}"])
 
 def convert_import_node(node):
-    case Map.get(node, "modules_import"):
+    case Elixir.Map.get(node, "modules_import"):
         None -> "not implemened from"
         _    ->
             import_commands = node
-                |> Map.get("modules_import")
-                |> Enum.map(lambda imp:
-                    name = Map.get(imp, "name")
-                    alias = Map.get(imp, "alias")
+                |> Elixir.Map.get("modules_import")
+                |> Elixir.Enum.map(lambda imp:
+                    name = Elixir.Map.get(imp, "name")
+                    alias = Elixir.Map.get(imp, "alias")
 
-                    case String.contains?(name, "."):
+                    case Elixir.String.contains?(name, "."):
                         True ->
                             name = name
-                                |> String.split(".")
-                                |> Enum.map(lambda i: Enum.join([':', i]))
-                                |> Enum.join(', ')
-                        False -> Enum.join([':', name])
+                                |> Elixir.String.split(".")
+                                |> Elixir.Enum.map(lambda i: Elixir.Enum.join([':', i]))
+                                |> Elixir.Enum.join(', ')
+                        False -> Elixir.Enum.join([':', name])
 
-                    import_command = Enum.join([
+                    import_command = Elixir.Enum.join([
                         "{:import, [context: Elixir], ",
                         "[{:__aliases__, [alias: false], ",
                         "[", name, "]}]}"
                     ])
 
-                    result = case Map.get(imp, "alias"):
+                    result = case Elixir.Map.get(imp, "alias"):
                         None -> import_command
-                        _ -> Enum.join([
+                        _ -> Elixir.Enum.join([
                             "{:__block__, [], [",
                                 import_command,
                                 ", {:alias, [context: Elixir], [",
@@ -324,37 +322,37 @@ def convert_import_node(node):
                         ])
                     result
                 )
-                |> Enum.join(', ')
+                |> Elixir.Enum.join(', ')
 
-            Enum.join(["{:__block__, [], [", import_commands, "]}"])
+            Elixir.Enum.join(["{:__block__, [], [", import_commands, "]}"])
 
 def build_single_pipe(node):
-    left = node |> Map.get("left_node") |> convert()
-    right = node |> Map.get("right_node") |> convert()
+    left = node |> Elixir.Map.get("left_node") |> convert()
+    right = node |> Elixir.Map.get("right_node") |> convert()
     build_single_pipe(left, right)
 
 def build_single_pipe(left, right):
-    left = case is_map(left):
+    left = case Elixir.Kernel.is_map(left):
         True -> left |> convert()
         False -> left
 
-    right = case is_map(right):
+    right = case Elixir.Kernel.is_map(right):
         True -> right |> convert()
         False -> right
 
-    Enum.join([
+    Elixir.Enum.join([
         "{:|>, [context: Elixir, import: Kernel], [",
         left, ",", right, "]}", ''
     ], "")
 
 def is_pipenode(node):
-    (node |> Map.get("NodeType")) == "PipeNode"
+    (node |> Elixir.Map.get("NodeType")) == "PipeNode"
 
 def get_childs(right_or_left_node):
     case is_pipenode(right_or_left_node):
         True -> [
-            get_childs(right_or_left_node |> Map.get("left_node")),
-            get_childs(right_or_left_node |> Map.get("right_node"))
+            get_childs(right_or_left_node |> Elixir.Map.get("left_node")),
+            get_childs(right_or_left_node |> Elixir.Map.get("right_node"))
         ]
         False -> [right_or_left_node]
 
@@ -365,30 +363,30 @@ def convert_pipe_node(node):
 
     build_multiple_pipes = lambda node:
         all = [
-            get_childs(node |> Map.get("left_node")),
-            get_childs(node |> Map.get("right_node"))
+            get_childs(node |> Elixir.Map.get("left_node")),
+            get_childs(node |> Elixir.Map.get("right_node"))
         ]
-            |> List.flatten()
+            |> Elixir.List.flatten()
 
         first = build_single_pipe(
-            all |> Enum.at(0), all |> Enum.at(1)
+            all |> Elixir.Enum.at(0), all |> Elixir.Enum.at(1)
         )
 
-        [first, all |> Enum.drop(2)]
-            |> List.flatten()
-            |> Enum.reduce(lambda x, acc:
+        [first, all |> Elixir.Enum.drop(2)]
+            |> Elixir.List.flatten()
+            |> Elixir.Enum.reduce(lambda x, acc:
                 build_single_pipe(acc, x)
             )
 
-    case is_pipenode(node |> Map.get("right_node")):
+    case is_pipenode(node |> Elixir.Map.get("right_node")):
         False -> build_single_pipe(node)
         True -> build_multiple_pipes(node)
 
 def convert_unaryop_node(node):
-    value = convert(node |> Map.get("node"))
+    value = convert(node |> Elixir.Map.get("node"))
 
-    tok_type = node |> Map.get("op_tok") |> Map.get("type")
-    tok_value = node |> Map.get("op_tok") |> Map.get("value")
+    tok_type = node |> Elixir.Map.get("op_tok") |> Elixir.Map.get("type")
+    tok_value = node |> Elixir.Map.get("op_tok") |> Elixir.Map.get("value")
 
     cases = [
         tok_type == "KEYWORD" and tok_value == "not",
@@ -397,17 +395,17 @@ def convert_unaryop_node(node):
     ]
 
     not_case = lambda value:
-        Enum.join([
+        Elixir.Enum.join([
             "{:__block__, [], [{:!, [context: Elixir, import: Kernel], [", value, "]}]}"
         ])
 
     plus_case = lambda value:
-        Enum.join([
+        Elixir.Enum.join([
             "{:+, [context: Elixir, import: Kernel], [", value, "]}"
         ])
 
     minus_case = lambda value:
-        Enum.join([
+        Elixir.Enum.join([
             "{:-, [context: Elixir, import: Kernel], [", value, "]}"
         ])
 
@@ -419,17 +417,17 @@ def convert_unaryop_node(node):
 
 def convert_tuple_node(node):
     items = node
-        |> Map.get("element_nodes")
-        |> Enum.map(&convert/1)
-        |> Enum.join(", ")
+        |> Elixir.Map.get("element_nodes")
+        |> Elixir.Enum.map(&convert/1)
+        |> Elixir.Enum.join(", ")
 
-    Enum.join(["{:{}, [], [", items, "]}"])
+    Elixir.Enum.join(["{:{}, [], [", items, "]}"])
 
 def convert_staticaccess_node(node):
-    to_be_accesed = convert(Map.get(node, "node"))
-    value_to_find = convert(Map.get(node, "node_value"))
+    to_be_accesed = convert(Elixir.Map.get(node, "node"))
+    value_to_find = convert(Elixir.Map.get(node, "node_value"))
 
-    Enum.join([
+    Elixir.Enum.join([
         "{{:., [], [{:__aliases__, [alias: false], [:Map]}, :fetch!]}, [], [",
         to_be_accesed, ", ", value_to_find, "]}"
     ])

--- a/src/Fcore/generator/Conversor.fy
+++ b/src/Fcore/generator/Conversor.fy
@@ -189,27 +189,6 @@ def convert_funcasvariable_node(node):
         name, ", [], Elixir}, ", arity, "]}]}"
     ])
 
-def convert_module_to_ast(module_name, compiled_body):
-    module_name = case String.contains?(module_name, "."):
-        False -> Enum.join([":", module_name])
-        True ->
-            module_name = module_name
-                |> String.split('.')
-                |> Enum.map(lambda i: Enum.join([":", i]))
-                |> Enum.join(", ")
-
-            Enum.join([
-                "{:__aliases__, [alias: false], [",
-                module_name,
-                "]}"
-            ])
-
-    Enum.join([
-        "{:defmodule, [line: 1], ",
-        "[{:__aliases__, [line: 1], [", module_name, "]}, ",
-        "[do: ", compiled_body, "]]}"
-    ])
-
 def convert_binop_node(node):
     a = convert(Map.get(node, "left_node"))
     b = convert(Map.get(node, "right_node"))

--- a/src/Fcore/lexer/__init__.fy
+++ b/src/Fcore/lexer/__init__.fy
@@ -17,15 +17,15 @@ def position(idx, ln, col):
     {"idx": idx, "ln": ln, "col": col}
 
 def advance(state):
-    idx = state |> Map.get("position") |> Map.get("idx")
-    ln = state |> Map.get("position") |> Map.get("ln")
-    col = state |> Map.get("position") |> Map.get("col")
-    text = state |> Map.get("text")
+    idx = state |> Elixir.Map.get("position") |> Elixir.Map.get("idx")
+    ln = state |> Elixir.Map.get("position") |> Elixir.Map.get("ln")
+    col = state |> Elixir.Map.get("position") |> Elixir.Map.get("col")
+    text = state |> Elixir.Map.get("text")
 
-    prev_position = Map.get(state, 'position')
+    prev_position = Elixir.Map.get(state, 'position')
 
     idx = idx + 1
-    current_char = text |> String.at(idx)
+    current_char = text |> Elixir.String.at(idx)
 
     new_pos = case current_char == '\n':
         True -> position(idx, ln + 1, -1)
@@ -37,42 +37,42 @@ def advance(state):
         "current_char": current_char
     }
 
-    Map.merge(state, new_state)
+    Elixir.Map.merge(state, new_state)
 
 def set_error(state, error):
-    Map.put(
+    Elixir.Map.put(
         state,
         "error",
         {
             "msg": error,
-            "pos_start": Map.get(state, 'position'),
-            "pos_end": Map.get(state, 'position')
+            "pos_start": Elixir.Map.get(state, 'position'),
+            "pos_end": Elixir.Map.get(state, 'position')
         }
     )
 
 def parse(state):
-    case Map.get(state, "error"):
+    case Elixir.Map.get(state, "error"):
         None ->
-            cc = state |> Map.get("current_char")
-            pos = state |> Map.get("position")
+            cc = state |> Elixir.Map.get("current_char")
+            pos = state |> Elixir.Map.get("position")
 
             case:
                 cc == None -> state
                 cc == "#" -> parse(skip_comment(state))
-                cc == " " and Map.get(pos, "col") == 0 -> parse(make_ident(state))
+                cc == " " and Elixir.Map.get(pos, "col") == 0 -> parse(make_ident(state))
                 cc == " " or cc == '\t' -> parse(advance(state))
                 cc == "\n" ->
                     state
-                        |> Map.put("current_ident_level", 0)
+                        |> Elixir.Map.put("current_ident_level", 0)
                         |> Fcore.Lexer.Tokens.add_token("NEWLINE")
                         |> advance()
                         |> parse()
                 cc == ':' -> parse(make_do_or_token(state))
                 cc == "'" or cc == '"' -> parse(make_string(state))
-                String.contains?(Fcore.Lexer.Consts.identifier_chars(True), cc) ->
+                Elixir.String.contains?(Fcore.Lexer.Consts.identifier_chars(True), cc) ->
                     state |> make_identifier() |> parse()
                 cc == "&" -> simple_maker(state, "ECOM")
-                String.contains?(Fcore.Lexer.Consts.digists(), cc) -> parse(make_number(state))
+                Elixir.String.contains?(Fcore.Lexer.Consts.digists(), cc) -> parse(make_number(state))
                 cc == "^" -> simple_maker(state, "PIN")
                 cc == "," -> simple_maker(state, "COMMA")
                 cc == "+" -> simple_maker(state, "PLUS")
@@ -90,7 +90,7 @@ def parse(state):
                 cc == '=' -> double_maker(state, "EQ", "=", "EE")
                 cc == '!' -> expected_double_maker(state, "!", "NE", "=")
                 cc == '|' -> expected_double_maker(state, "|", "PIPE", ">")
-                True -> set_error(state, Enum.join(["IllegalCharError: ", cc]))
+                True -> set_error(state, Elixir.Enum.join(["IllegalCharError: ", cc]))
         _ -> state
 
 def simple_maker(st, type):
@@ -101,7 +101,7 @@ def simple_maker(st, type):
 
 def double_maker(st, type_1, second_char, type_2):
     st = st |> advance()
-    cc = Map.get(st, "current_char")
+    cc = Elixir.Map.get(st, "current_char")
 
     case:
         cc == second_char -> st |> Fcore.Lexer.Tokens.add_token(type_2) |> advance() |> parse()
@@ -110,57 +110,57 @@ def double_maker(st, type_1, second_char, type_2):
 
 def expected_double_maker(st, first, type, expected):
     st = st |> advance()
-    cc = Map.get(st, "current_char")
+    cc = Elixir.Map.get(st, "current_char")
 
     case:
         cc == expected -> st |> Fcore.Lexer.Tokens.add_token(type) |> advance() |> parse()
-        True -> st |> set_error(Enum.join(["Expected '", expected, "' after '", first, "'"]))
+        True -> st |> set_error(Elixir.Enum.join(["Expected '", expected, "' after '", first, "'"]))
 
 def make_ident(state):
-    first_char = Map.get(state, "current_char")
+    first_char = Elixir.Map.get(state, "current_char")
 
     state = loop_while(state, lambda cc:
         cc != None and cc == " "
     )
 
-    total_spaces = Enum.join([first_char, Map.get(state, "result")]) |> String.length()
+    total_spaces = Elixir.Enum.join([first_char, Elixir.Map.get(state, "result")]) |> Elixir.String.length()
 
     state = case rem(total_spaces, 4) != 0:
         True -> set_error(state, "Identation problem")
-        False -> state |> Map.put("current_ident_level", max(0, total_spaces))
+        False -> state |> Elixir.Map.put("current_ident_level", max(0, total_spaces))
 
-    state |> Map.delete("result")
+    state |> Elixir.Map.delete("result")
 
 def loop_while(st, func):
     st = advance(st)
-    cc = Map.get(st, "current_char")
-    result = Map.get(st, "result")
+    cc = Elixir.Map.get(st, "current_char")
+    result = Elixir.Map.get(st, "result")
 
     valid = func(cc)
 
     case valid:
-        True -> Map.put(st, "result", Enum.join([result, cc])) |> loop_while(func)
+        True -> Elixir.Map.put(st, "result", Elixir.Enum.join([result, cc])) |> loop_while(func)
         False -> st
 
 
 def make_do_or_token(state):
-    pos_start = Map.get(state, "position")
+    pos_start = Elixir.Map.get(state, "position")
     state = advance(state)
 
-    first_char = Map.get(state, "current_char")
+    first_char = Elixir.Map.get(state, "current_char")
 
-    case first_char != None and String.contains?(Fcore.Lexer.Consts.letters(), first_char):
+    case first_char != None and Elixir.String.contains?(Fcore.Lexer.Consts.letters(), first_char):
         True ->
             state = state
-                |> Map.put("result",  Map.get(state, "current_char"))
+                |> Elixir.Map.put("result",  Elixir.Map.get(state, "current_char"))
                 |> loop_while(lambda cc:
-                    cc != None and String.contains?(Fcore.Lexer.Consts.letters_digits(), cc)
+                    cc != None and Elixir.String.contains?(Fcore.Lexer.Consts.letters_digits(), cc)
                 )
             state = state
                 |> Fcore.Lexer.Tokens.add_token(
-                    "ATOM", Map.get(state, "result"), pos_start
+                    "ATOM", Elixir.Map.get(state, "result"), pos_start
                 )
-                |> Map.delete("result")
+                |> Elixir.Map.delete("result")
 
             state
         False ->
@@ -170,8 +170,8 @@ def make_do_or_token(state):
 
 
 def make_string(state):
-    pos_start = Map.get(state, "position")
-    string_char_type = Map.get(state, "current_char") # ' or "
+    pos_start = Elixir.Map.get(state, "position")
+    string_char_type = Elixir.Map.get(state, "current_char") # ' or "
 
     state = loop_while(state, lambda cc:
         cc != string_char_type and cc != None
@@ -181,18 +181,18 @@ def make_string(state):
     state = advance(state)
 
     string = state
-        |> Map.get("result", "")
-        |> String.graphemes()
-        |> Enum.map(lambda i:
-            Enum.join(['\\', '"']) if i == '"' else i
+        |> Elixir.Map.get("result", "")
+        |> Elixir.String.graphemes()
+        |> Elixir.Enum.map(lambda i:
+            Elixir.Enum.join(['\\', '"']) if i == '"' else i
         )
-        |> Enum.join()
+        |> Elixir.Enum.join()
 
     state
         |> Fcore.Lexer.Tokens.add_token(
             "STRING", string, pos_start
         )
-        |> Map.delete("result")
+        |> Elixir.Map.delete("result")
 
 def skip_comment(state):
     state = advance(state)
@@ -200,21 +200,21 @@ def skip_comment(state):
     state = loop_while(state, lambda cc:
         cc != '\n'
     )
-    Map.delete(state, "result")
+    Elixir.Map.delete(state, "result")
 
 def make_number(state):
-    pos_start = Map.get(state, "position")
-    first_number = Map.get(state, "current_char")
+    pos_start = Elixir.Map.get(state, "position")
+    first_number = Elixir.Map.get(state, "current_char")
 
     state = loop_while(state, lambda cc:
-        cc != None and String.contains?(Enum.join([Fcore.Lexer.Consts.digists(), '._']), cc)
+        cc != None and Elixir.String.contains?(Elixir.Enum.join([Fcore.Lexer.Consts.digists(), '._']), cc)
     )
-    result = Enum.join([first_number, Map.get(state, "result")])
+    result = Elixir.Enum.join([first_number, Elixir.Map.get(state, "result")])
 
     state = case:
-        (String.split(result, ".") |> Enum.count()) > 2 ->
-            set_error(state, Enum.join(["IllegalCharError: ."]))
-        String.contains?(result, '.') ->
+        (Elixir.String.split(result, ".") |> Elixir.Enum.count()) > 2 ->
+            set_error(state, Elixir.Enum.join(["IllegalCharError: ."]))
+        Elixir.String.contains?(result, '.') ->
             state
                 |> Fcore.Lexer.Tokens.add_token(
                     "FLOAT", result, pos_start
@@ -225,22 +225,22 @@ def make_number(state):
                     "INT", result, pos_start
                 )
 
-    state |> Map.delete("result")
+    state |> Elixir.Map.delete("result")
 
 def make_identifier(state):
-    pos_start = Map.get(state, "position")
-    first_char = Map.get(state, "current_char")
+    pos_start = Elixir.Map.get(state, "position")
+    first_char = Elixir.Map.get(state, "current_char")
 
     state = loop_while(state, lambda cc:
-        cc != None and String.contains?(Fcore.Lexer.Consts.identifier_chars(False), cc)
+        cc != None and Elixir.String.contains?(Fcore.Lexer.Consts.identifier_chars(False), cc)
     )
 
-    result = Enum.join([first_char, Map.get(state, "result")])
+    result = Elixir.Enum.join([first_char, Elixir.Map.get(state, "result")])
 
-    type = case Enum.member?(Fcore.Lexer.Tokens.keywords(), result):
+    type = case Elixir.Enum.member?(Fcore.Lexer.Tokens.keywords(), result):
         True -> "KEYWORD"
         False -> "IDENTIFIER"
 
     state
         |> Fcore.Lexer.Tokens.add_token(type, result, pos_start)
-        |> Map.delete("result")
+        |> Elixir.Map.delete("result")

--- a/src/Fcore/lexer/consts.fy
+++ b/src/Fcore/lexer/consts.fy
@@ -5,9 +5,9 @@ def letters():
     'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 
 def letters_digits():
-    Enum.join([letters(), digists()])
+    Elixir.Enum.join([letters(), digists()])
 
 def identifier_chars(firs_char):
     case firs_char:
-        True -> Enum.join([letters(), "_"])
-        False -> Enum.join([letters(), digists(), "_.?!"])
+        True -> Elixir.Enum.join([letters(), "_"])
+        False -> Elixir.Enum.join([letters(), digists(), "_.?!"])

--- a/src/Fcore/lexer/tokens.fy
+++ b/src/Fcore/lexer/tokens.fy
@@ -33,7 +33,7 @@ def valid_token_type?(type):
         "PIN",
         "EOF"
     ]
-    Enum.member?(tokens, type)
+    Elixir.Enum.member?(tokens, type)
 
 def keywords():
     [
@@ -42,11 +42,11 @@ def keywords():
     ]
 
 def add_eof_token(state):
-    tokens = Map.get(state, "tokens")
+    tokens = Elixir.Map.get(state, "tokens")
 
     start_end = case tokens:
         [] -> {"idx": 0, "ln": 0, "col": 0}
-        _ -> Map.get(Enum.at(tokens, -1), "pos_end")
+        _ -> Elixir.Map.get(Elixir.Enum.at(tokens, -1), "pos_end")
 
     add_token(state, "EOF", None, start_end)
 
@@ -54,20 +54,20 @@ def add_token(state, type):
     add_token(state, type, None)
 
 def add_token(state, type, value):
-    pos_start = Map.get(state, 'position')
+    pos_start = Elixir.Map.get(state, 'position')
     add_token(state, type, value, pos_start)
 
 def add_token(state, type, value, pos_start):
-    ident = state |> Map.get("current_ident_level")
+    ident = state |> Elixir.Map.get("current_ident_level")
 
-    pos_end = state |> Map.get("position")
+    pos_end = state |> Elixir.Map.get("position")
 
-    pos_end = case Map.get(pos_end, 'col') != -1:
+    pos_end = case Elixir.Map.get(pos_end, 'col') != -1:
         True -> pos_end
-        False -> Map.get(state, 'prev_position')
+        False -> Elixir.Map.get(state, 'prev_position')
 
     case valid_token_type?(type):
-        False -> raise Enum.join(["Invalid Token Type: ", type])
+        False -> raise Elixir.Enum.join(["Invalid Token Type: ", type])
         True -> None
 
     token = {
@@ -78,4 +78,4 @@ def add_token(state, type, value, pos_start):
         "pos_end": pos_end
     }
 
-    Map.put(state, "tokens", [Map.get(state, "tokens"), token] |> List.flatten())
+    Elixir.Map.put(state, "tokens", [Elixir.Map.get(state, "tokens"), token] |> Elixir.List.flatten())

--- a/src/Fcore/parser/nodes.fy
+++ b/src/Fcore/parser/nodes.fy
@@ -5,16 +5,16 @@ def make_number_node(tok):
     {
         "NodeType": "NumberNode",
         "tok": tok,
-        "pos_start": Map.get(tok, "pos_start"),
-        "pos_end": Map.get(tok, "pos_end")
+        "pos_start": Elixir.Map.get(tok, "pos_start"),
+        "pos_end": Elixir.Map.get(tok, "pos_end")
     }
 
 def make_string_node(tok):
     {
         "NodeType": "StringNode",
         "tok": tok,
-        "pos_start": Map.get(tok, "pos_start"),
-        "pos_end": Map.get(tok, "pos_end")
+        "pos_start": Elixir.Map.get(tok, "pos_start"),
+        "pos_end": Elixir.Map.get(tok, "pos_end")
     }
 
 def make_varaccess_node(var_name_tok, pinned):
@@ -22,8 +22,8 @@ def make_varaccess_node(var_name_tok, pinned):
         "NodeType": "VarAccessNode",
         "var_name_tok": var_name_tok,
         "pinned": pinned,
-        "pos_start": Map.get(var_name_tok, "pos_start"),
-        "pos_end": Map.get(var_name_tok, "pos_end")
+        "pos_start": Elixir.Map.get(var_name_tok, "pos_start"),
+        "pos_end": Elixir.Map.get(var_name_tok, "pos_end")
     }
 
 def make_staticaccess_node(node_left, node_value, pos_end):
@@ -31,7 +31,7 @@ def make_staticaccess_node(node_left, node_value, pos_end):
         "NodeType": "StaticAccessNode",
         "node": node_left,
         "node_value": node_value,
-        "pos_start": Map.get(node_left, "pos_start"),
+        "pos_start": Elixir.Map.get(node_left, "pos_start"),
         "pos_end": pos_end
     }
 
@@ -41,17 +41,17 @@ def make_if_node(comp_expr, true_expr, false_expr):
         "comp_expr": comp_expr,
         "true_case": true_expr,
         "false_case": false_expr,
-        "pos_start": Map.get(comp_expr, "pos_start"),
-        "pos_end": Map.get(false_expr, "pos_end")
+        "pos_start": Elixir.Map.get(comp_expr, "pos_start"),
+        "pos_end": Elixir.Map.get(false_expr, "pos_end")
     }
 
 def make_funcasvariable_node(var_name_tok, arity, pos_start):
     {
         "NodeType": "FuncAsVariableNode",
         "var_name_tok": var_name_tok,
-        "arity": String.to_integer(Map.get(arity, 'value')),
+        "arity": Elixir.String.to_integer(Elixir.Map.get(arity, 'value')),
         "pos_start": pos_start,
-        "pos_end": Map.get(arity, "pos_end")
+        "pos_end": Elixir.Map.get(arity, "pos_end")
     }
 
 def make_pipe_node(left_node, right_node):
@@ -59,8 +59,8 @@ def make_pipe_node(left_node, right_node):
         "NodeType": "PipeNode",
         "left_node": left_node,
         "right_node": right_node,
-        "pos_start": Map.get(left_node, "pos_start"),
-        "pos_end": Map.get(right_node, "pos_end")
+        "pos_start": Elixir.Map.get(left_node, "pos_start"),
+        "pos_end": Elixir.Map.get(right_node, "pos_end")
     }
 
 def make_case_node(expr, cases, pos_start, pos_end):
@@ -77,8 +77,8 @@ def make_in_node(left_expr, right_expr):
         "NodeType": "InNode",
         "left_expr": left_expr,
         "right_expr": right_expr,
-        "pos_start": Map.get(left_expr, "pos_start"),
-        "pos_end": Map.get(right_expr, "pos_end")
+        "pos_start": Elixir.Map.get(left_expr, "pos_start"),
+        "pos_end": Elixir.Map.get(right_expr, "pos_end")
     }
 
 def make_statements_node(statements, pos_start, pos_end):
@@ -93,8 +93,8 @@ def make_atom_node(tok):
     {
         "NodeType": "AtomNode",
         "tok": tok,
-        "pos_start": Map.get(tok, "pos_start"),
-        "pos_end": Map.get(tok, "pos_end")
+        "pos_start": Elixir.Map.get(tok, "pos_start"),
+        "pos_end": Elixir.Map.get(tok, "pos_end")
     }
 
 def make_list_node(element_nodes, pos_start, pos_end):
@@ -137,7 +137,7 @@ def make_raise_node(expr, pos_start):
         "NodeType": "RaiseNode",
         "expr": expr,
         "pos_start": pos_start,
-        "pos_end": Map.get(expr, 'pos_end')
+        "pos_end": Elixir.Map.get(expr, 'pos_end')
     }
 
 
@@ -146,14 +146,14 @@ def make_funcdef_node(var_name_tok, arg_name_toks, body_node, pos_start):
         "NodeType": "FuncDefNode",
         "var_name_tok": var_name_tok,
         "arg_name_toks": arg_name_toks,
-        "arity": Enum.count(arg_name_toks),
+        "arity": Elixir.Enum.count(arg_name_toks),
         "body_node": body_node,
         "pos_start": pos_start,
-        "pos_end": Map.get(body_node, 'pos_end')
+        "pos_end": Elixir.Map.get(body_node, 'pos_end')
     }
 
 def make_lambda_node(var_name_tok, arg_name_toks, body_node, pos_start):
-    Map.merge(
+    Elixir.Map.merge(
         make_funcdef_node(var_name_tok, arg_name_toks, body_node, pos_start),
         {"NodeType": "LambdaNode"}
     )
@@ -165,8 +165,8 @@ def make_call_node(node_to_call, arg_nodes, keywords, pos_end):
         "node_to_call": node_to_call,
         "arg_nodes": arg_nodes,
         "keywords": keywords,
-        "arity": Enum.count(arg_nodes),
-        "pos_start": Map.get(node_to_call, 'pos_start'),
+        "arity": Elixir.Enum.count(arg_nodes),
+        "pos_start": Elixir.Map.get(node_to_call, 'pos_start'),
         "pos_end": pos_end,
         "local_call": False
     }
@@ -178,8 +178,8 @@ def make_unary_node(tok, node):
             "NodeType": "UnaryOpNode",
             "op_tok": tok,
             "node": node,
-            "pos_start": Map.get(tok, "pos_start"),
-            "pos_end": Map.get(tok, "pos_end")
+            "pos_start": Elixir.Map.get(tok, "pos_start"),
+            "pos_end": Elixir.Map.get(tok, "pos_end")
         }
 
 def make_bin_op_node(left, op_tok, right):
@@ -194,6 +194,6 @@ def make_bin_op_node(left, op_tok, right):
                     "left_node": left,
                     "op_tok": op_tok,
                     "right_node": right,
-                    "pos_start": Map.get(left, "pos_start"),
-                    "pos_end": Map.get(right, "pos_end")
+                    "pos_start": Elixir.Map.get(left, "pos_start"),
+                    "pos_end": Elixir.Map.get(right, "pos_end")
                 }

--- a/src/Fcore/parser/pos/__init__.fy
+++ b/src/Fcore/parser/pos/__init__.fy
@@ -1,9 +1,9 @@
 def execute(state):
-    case Map.get(state, 'error'):
+    case Elixir.Map.get(state, 'error'):
         None ->
             node = state
-                |> Map.get('node')
+                |> Elixir.Map.get('node')
                 |> Fcore.Parser.Pos.Localcalls.convert_local_function_calls([])
 
-            Map.put(state, 'node', node)
+            Elixir.Map.put(state, 'node', node)
         _ -> state

--- a/src/Fcore/parser/pos/localcalls.fy
+++ b/src/Fcore/parser/pos/localcalls.fy
@@ -17,7 +17,7 @@ def convert_local_function_calls(node, var_names_avaliable):
         True -> raise "None should not be in the var names"
         False -> None
 
-    case Map.get(node, 'NodeType') if is_map(node) else None:
+    case Elixir.Map.get(node, 'NodeType') if Elixir.Kernel.is_map(node) else None:
         'StatementsNode' -> resolve_statements(node, var_names_avaliable)
         'PatternMatchNode' -> resolve_pattern(node, var_names_avaliable)
         'FuncDefNode' -> resolve_func_or_lambda(node, var_names_avaliable)
@@ -37,57 +37,57 @@ def convert_local_function_calls(node, var_names_avaliable):
 
 
 def get_variables_bound_in_pattern(node):
-    node_type = Map.get(node, 'NodeType')
+    node_type = Elixir.Map.get(node, 'NodeType')
 
-    filter_types = lambda i: Map.get(i, 'NodeType') in Fcore.Parser.Nodes.node_types_accept_pattern()
+    filter_types = lambda i: Elixir.Map.get(i, 'NodeType') in Fcore.Parser.Nodes.node_types_accept_pattern()
 
     case:
         node_type == 'MapNode' ->
             node
-                |> Map.get("pairs_list")
-                |> List.flatten()
-                |> Enum.filter(filter_types)
-                |> Enum.map(&get_variables_bound_in_pattern/1)
+                |> Elixir.Map.get("pairs_list")
+                |> Elixir.List.flatten()
+                |> Elixir.Enum.filter(filter_types)
+                |> Elixir.Enum.map(&get_variables_bound_in_pattern/1)
         node_type in ['TupleNode', 'ListNode'] ->
             node
-                |> Map.get('element_nodes')
-                |> Enum.filter(filter_types)
-                |> Enum.map(&get_variables_bound_in_pattern/1)
+                |> Elixir.Map.get('element_nodes')
+                |> Elixir.Enum.filter(filter_types)
+                |> Elixir.Enum.map(&get_variables_bound_in_pattern/1)
         "VarAccessNode" ->
-            Map.get(node, "var_name_tok") |> Map.get("value")
+            Elixir.Map.get(node, "var_name_tok") |> Elixir.Map.get("value")
         True ->
-            raise Enum.join([
+            raise Elixir.Enum.join([
                 "The node type '", node_type, "' doesnt work as a pattern match"
             ])
 
 
 def resolve_statements(node, var_names_avaliable):
-    defined_vars_this_level = Map.get(node, 'statement_nodes')
-        |> Enum.filter(lambda i:
-            Map.get(i, 'NodeType') == 'PatternMatchNode'
+    defined_vars_this_level = Elixir.Map.get(node, 'statement_nodes')
+        |> Elixir.Enum.filter(lambda i:
+            Elixir.Map.get(i, 'NodeType') == 'PatternMatchNode'
         )
-        |> Enum.map(lambda i:
+        |> Elixir.Enum.map(lambda i:
             # only the left node can assign any variable
-            get_variables_bound_in_pattern(Map.get(i, 'left_node'))
+            get_variables_bound_in_pattern(Elixir.Map.get(i, 'left_node'))
         )
-        |> List.flatten()
+        |> Elixir.List.flatten()
 
-    var_names_avaliable = List.flatten([var_names_avaliable, defined_vars_this_level])
+    var_names_avaliable = Elixir.List.flatten([var_names_avaliable, defined_vars_this_level])
 
-    statement_nodes = Map.get(node, "statement_nodes")
-        |> Enum.map(lambda i:
+    statement_nodes = Elixir.Map.get(node, "statement_nodes")
+        |> Elixir.Enum.map(lambda i:
             convert_local_function_calls(i, var_names_avaliable)
         )
 
-    node |> Map.put('statement_nodes', statement_nodes)
+    node |> Elixir.Map.put('statement_nodes', statement_nodes)
 
 
 def resolve_pattern(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "right_node": convert_local_function_calls(
-                Map.get(node, "right_node"), var_names_avaliable
+                Elixir.Map.get(node, "right_node"), var_names_avaliable
             )
         }
     )
@@ -95,61 +95,61 @@ def resolve_pattern(node, var_names_avaliable):
 
 def resolve_func_or_lambda(func_def_node, var_names_avaliable):
     func_arguments = func_def_node
-        |> Map.get('arg_name_toks')
-        |> Enum.map(lambda i:
-            Map.get(i, 'value')
+        |> Elixir.Map.get('arg_name_toks')
+        |> Elixir.Enum.map(lambda i:
+            Elixir.Map.get(i, 'value')
         )
 
-    body_node = Map.get(func_def_node, 'body_node')
+    body_node = Elixir.Map.get(func_def_node, 'body_node')
         |> convert_local_function_calls(
-            List.flatten(var_names_avaliable, func_arguments)
+            Elixir.List.flatten(var_names_avaliable, func_arguments)
         )
 
-    Map.put(func_def_node, 'body_node', body_node)
+    Elixir.Map.put(func_def_node, 'body_node', body_node)
 
 
 def resolve_call_node(node, var_names_avaliable):
     local_call = case:
-        (Map.get(node, 'node_to_call') |> Map.get('NodeType')) == 'VarAccessNode' ->
-            func_name = Map.get(node, 'node_to_call')
-                |> Map.get('var_name_tok')
-                |> Map.get('value')
+        (Elixir.Map.get(node, 'node_to_call') |> Elixir.Map.get('NodeType')) == 'VarAccessNode' ->
+            func_name = Elixir.Map.get(node, 'node_to_call')
+                |> Elixir.Map.get('var_name_tok')
+                |> Elixir.Map.get('value')
 
-            not String.contains?(func_name, ".") and func_name in var_names_avaliable
-        (Map.get(node, 'node_to_call') |> Map.get('NodeType')) == 'CallNode' -> True
-        (Map.get(node, 'node_to_call') |> Map.get('NodeType')) == 'StaticAccessNode' -> True
+            not Elixir.String.contains?(func_name, ".") and func_name in var_names_avaliable
+        (Elixir.Map.get(node, 'node_to_call') |> Elixir.Map.get('NodeType')) == 'CallNode' -> True
+        (Elixir.Map.get(node, 'node_to_call') |> Elixir.Map.get('NodeType')) == 'StaticAccessNode' -> True
         True -> False
 
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             'node_to_call': convert_local_function_calls(
-                Map.get(node, 'node_to_call'), var_names_avaliable
+                Elixir.Map.get(node, 'node_to_call'), var_names_avaliable
             ),
             'local_call': local_call,
-            "arg_nodes": Enum.map(
-                Map.get(node, "arg_nodes"),
+            "arg_nodes": Elixir.Enum.map(
+                Elixir.Map.get(node, "arg_nodes"),
                 lambda i: convert_local_function_calls(i, var_names_avaliable)
             ),
-            "keywords": Map.new(
-                Map.get(node, "keywords"),
+            "keywords": Elixir.Map.new(
+                Elixir.Map.get(node, "keywords"),
                 lambda i:
-                    key = elem(i, 0)
-                    value = elem(i, 1) |> convert_local_function_calls(var_names_avaliable)
-                    Map.to_list({key: value}) |> Enum.at(0)
+                    key = Elixir.Kernel.elem(i, 0)
+                    value = Elixir.Kernel.elem(i, 1) |> convert_local_function_calls(var_names_avaliable)
+                    Elixir.Map.to_list({key: value}) |> Elixir.Enum.at(0)
             )
         }
     )
 
 
 def resolve_case_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
-            'expr': convert_local_function_calls(Map.get(node, 'expr'), var_names_avaliable),
+            'expr': convert_local_function_calls(Elixir.Map.get(node, 'expr'), var_names_avaliable),
             'cases': node
-                |> Map.get('cases')
-                |> Enum.map(lambda i:
+                |> Elixir.Map.get('cases')
+                |> Elixir.Enum.map(lambda i:
                     [condition, statements] = i
                     [condition, convert_local_function_calls(statements, var_names_avaliable)]
                 )
@@ -157,122 +157,122 @@ def resolve_case_node(node, var_names_avaliable):
     )
 
 def resolve_if_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "comp_expr": convert_local_function_calls(
-                Map.get(node, "comp_expr"), var_names_avaliable
+                Elixir.Map.get(node, "comp_expr"), var_names_avaliable
             ),
             "true_case": convert_local_function_calls(
-                Map.get(node, "true_case"), var_names_avaliable
+                Elixir.Map.get(node, "true_case"), var_names_avaliable
             ),
             "false_case": convert_local_function_calls(
-                Map.get(node, "false_case"), var_names_avaliable
+                Elixir.Map.get(node, "false_case"), var_names_avaliable
             )
         }
     )
 
 def resolve_pipe_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "left_node": convert_local_function_calls(
-                Map.get(node, "left_node"), var_names_avaliable
+                Elixir.Map.get(node, "left_node"), var_names_avaliable
             ),
             "right_node": convert_local_function_calls(
-                Map.get(node, "right_node"), var_names_avaliable
+                Elixir.Map.get(node, "right_node"), var_names_avaliable
             )
         }
     )
 
 def resolve_in_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "left_expr": convert_local_function_calls(
-                Map.get(node, "left_expr"), var_names_avaliable
+                Elixir.Map.get(node, "left_expr"), var_names_avaliable
             ),
             "right_expr": convert_local_function_calls(
-                Map.get(node, "right_expr"), var_names_avaliable
+                Elixir.Map.get(node, "right_expr"), var_names_avaliable
             )
         }
     )
 
 def resolve_varassign_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "value_node": convert_local_function_calls(
-                Map.get(node, "value_node"), var_names_avaliable
+                Elixir.Map.get(node, "value_node"), var_names_avaliable
             )
         }
     )
 
 def resolve_list_or_tuple_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
-            "element_nodes": Map.get(node, "element_nodes")
-                |> Enum.map(lambda i: convert_local_function_calls(i, var_names_avaliable))
+            "element_nodes": Elixir.Map.get(node, "element_nodes")
+                |> Elixir.Enum.map(lambda i: convert_local_function_calls(i, var_names_avaliable))
         }
     )
 
 def resolve_map_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
-            "pairs_list": Map.get(node, "pairs_list")
-                |> Enum.map(lambda i:
+            "pairs_list": Elixir.Map.get(node, "pairs_list")
+                |> Elixir.Enum.map(lambda i:
                     [
-                        convert_local_function_calls(Enum.at(i, 0), var_names_avaliable),
-                        convert_local_function_calls(Enum.at(i, 1), var_names_avaliable)
+                        convert_local_function_calls(Elixir.Enum.at(i, 0), var_names_avaliable),
+                        convert_local_function_calls(Elixir.Enum.at(i, 1), var_names_avaliable)
                     ]
                 )
         }
     )
 
 def resolve_raise_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "expr": convert_local_function_calls(
-                Map.get(node, "expr"), var_names_avaliable
+                Elixir.Map.get(node, "expr"), var_names_avaliable
             )
         }
     )
 
 def resolve_unary_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "node": convert_local_function_calls(
-                Map.get(node, "node"), var_names_avaliable
+                Elixir.Map.get(node, "node"), var_names_avaliable
             )
         }
     )
 
 def resolve_unary_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "left_node": convert_local_function_calls(
-                Map.get(node, "left_node"), var_names_avaliable
+                Elixir.Map.get(node, "left_node"), var_names_avaliable
             ),
             "right_node": convert_local_function_calls(
-                Map.get(node, "right_node"), var_names_avaliable
+                Elixir.Map.get(node, "right_node"), var_names_avaliable
             )
         }
     )
 
 def resolve_staticaccess_node(node, var_names_avaliable):
-    Map.merge(
+    Elixir.Map.merge(
         node,
         {
             "node": convert_local_function_calls(
-                Map.get(node, "node"), var_names_avaliable
+                Elixir.Map.get(node, "node"), var_names_avaliable
             ),
             "node_value": convert_local_function_calls(
-                Map.get(node, "node_value"), var_names_avaliable
+                Elixir.Map.get(node, "node_value"), var_names_avaliable
             )
         }
     )

--- a/src/Fcore/parser/utils.fy
+++ b/src/Fcore/parser/utils.fy
@@ -2,42 +2,42 @@ def valid_node?(node):
     case:
         node == None ->
             [False, "None is not a valid type of node"]
-        Map.get(node, "NodeType") == None ->
+        Elixir.Map.get(node, "NodeType") == None ->
             [False, "Node map must have 'NodeType'"]
         True ->
             [True, None]
 
 def add_node(state, node):
     case:
-        Map.get(state, 'error') != None -> state
+        Elixir.Map.get(state, 'error') != None -> state
         True ->
             case valid_node?(node):
                 [True, _] ->
-                    nodes = Map.get(state, 'nodes')
-                    Map.put(
-                        state, 'nodes', List.flatten([nodes, node])
+                    nodes = Elixir.Map.get(state, 'nodes')
+                    Elixir.Map.put(
+                        state, 'nodes', Elixir.List.flatten([nodes, node])
                     )
                 [False, reason] -> raise reason
 
 def has_error(state):
-    Map.get(state, "error") != None
+    Elixir.Map.get(state, "error") != None
 
 def tok_matchs(tok, type):
-    Map.get(tok, "type") == type
+    Elixir.Map.get(tok, "type") == type
 
 def tok_matchs(tok, type, value):
-    Map.get(tok, "type") == type and Map.get(tok, "value") == value
+    Elixir.Map.get(tok, "type") == type and Elixir.Map.get(tok, "value") == value
 
 def get_next_tok(state):
-    idx = state |> Map.get("current_tok_idx")
-    tokens = state |> Map.get("tokens")
+    idx = state |> Elixir.Map.get("current_tok_idx")
+    tokens = state |> Elixir.Map.get("tokens")
     idx = idx + 1
-    tokens |> Enum.at(idx)
+    tokens |> Elixir.Enum.at(idx)
 
 def set_error(state, msg, pos_start, pos_end):
-    case Map.get(state, 'error'):
+    case Elixir.Map.get(state, 'error'):
         None ->
-            state = Map.put(
+            state = Elixir.Map.put(
                 state, "error", {"msg": msg, "pos_start": pos_start, "pos_end": pos_end}
             )
             state

--- a/src/Fshell/__init__.fy
+++ b/src/Fshell/__init__.fy
@@ -5,34 +5,34 @@ def start(count, state):
     # to make space between lines
     case count:
         0 -> None
-        _ -> IO.puts(" ")
+        _ -> Elixir.IO.puts(" ")
 
-    head = IO.ANSI.format([
-        :black, :bright , "[", :cyan, count |> to_string(), :black, :bright, "]: "
+    head = Elixir.IO.ANSI.format([
+        :black, :bright , "[", :cyan, count |> Elixir.Kernel.to_string(), :black, :bright, "]: "
     ])
-    user_input = IO.gets(head)
+    user_input = Elixir.IO.gets(head)
 
-    case user_input |> String.trim():
+    case user_input |> Elixir.String.trim():
         "" -> start(count, state)
         _ ->
-            state = case user_input |> String.at(0):
+            state = case user_input |> Elixir.String.at(0):
                 "%" ->
-                    line_number = String.replace_prefix(user_input, "%", "")
-                        |> String.replace("\n", "")
-                        |> String.to_integer()
+                    line_number = Elixir.String.replace_prefix(user_input, "%", "")
+                        |> Elixir.String.replace("\n", "")
+                        |> Elixir.String.to_integer()
 
-                    text = state |> Map.get("text_per_line") |> Map.get(line_number)
+                    text = state |> Elixir.Map.get("text_per_line") |> Elixir.Map.get(line_number)
                     case text:
                         None -> raise "Line code not found"
                         _ -> execute(text)
                     state
                 _ ->
                     execute(user_input)
-                    text_per_line = Map.get(state, "text_per_line")
+                    text_per_line = Elixir.Map.get(state, "text_per_line")
 
                     state
-                        |> Map.merge({
-                            "text_per_line": Map.merge(text_per_line, {count: user_input})
+                        |> Elixir.Map.merge({
+                            "text_per_line": Elixir.Map.merge(text_per_line, {count: user_input})
                         })
 
             start(count + 1, state)
@@ -42,4 +42,4 @@ def execute(text):
 
     case result:
         None -> None
-        _ -> IO.inspect(result)
+        _ -> Elixir.IO.inspect(result)


### PR DESCRIPTION
To use any module of elixir now its necessary use the prefix `Elixir.`.

The next step is to do as elixir, and create our modules with the Fython prefix.

And, because of this PR, we now can have our own modules of python that have the same module that in elixir without any conflict. 